### PR TITLE
Add 12 more missing i18n keys to all 9 language files

### DIFF
--- a/content/cs.json
+++ b/content/cs.json
@@ -63,5 +63,18 @@
   "highlights_h": "Highlights",
   "gallery_h": "Galerie",
   "avail_label": "Kalendář",
-  "availability_h": "Dostupnost"
+  "availability_h": "Dostupnost",
+
+  "amenities_label": "Vybavení",
+  "weather_label": "Počasí",
+  "discover_olive": "Objevit Olive",
+  "discover_onyx": "Objevit Onyx",
+  "stat_beach": "na pláž",
+  "stat_opatija": "do Opatiji",
+  "stat_airport": "na letiště Pula",
+  "stat_plitvice": "k Plitvickým jezerům",
+  "explore_do_label": "Aktivity",
+  "explore_beaches_label": "Pláže",
+  "explore_trips_label": "Výlety",
+  "explore_food_label": "Jídlo a pití"
 }

--- a/content/de.json
+++ b/content/de.json
@@ -63,5 +63,18 @@
   "highlights_h": "Highlights",
   "gallery_h": "Galerie",
   "avail_label": "Kalender",
-  "availability_h": "Verfügbarkeit"
+  "availability_h": "Verfügbarkeit",
+
+  "amenities_label": "Ausstattung",
+  "weather_label": "Wetter",
+  "discover_olive": "Olive entdecken",
+  "discover_onyx": "Onyx entdecken",
+  "stat_beach": "zum Strand",
+  "stat_opatija": "bis Opatija",
+  "stat_airport": "bis Flughafen Pula",
+  "stat_plitvice": "bis Plitvicer Seen",
+  "explore_do_label": "Aktivitäten",
+  "explore_beaches_label": "Küste",
+  "explore_trips_label": "Tagesausflüge",
+  "explore_food_label": "Essen & Trinken"
 }

--- a/content/en.json
+++ b/content/en.json
@@ -63,5 +63,18 @@
   "highlights_h": "Highlights",
   "gallery_h": "Gallery",
   "avail_label": "Calendar",
-  "availability_h": "Availability"
+  "availability_h": "Availability",
+
+  "amenities_label": "Amenities",
+  "weather_label": "Weather",
+  "discover_olive": "Discover Olive",
+  "discover_onyx": "Discover Onyx",
+  "stat_beach": "to the beach",
+  "stat_opatija": "to Opatija",
+  "stat_airport": "to Pula airport",
+  "stat_plitvice": "to Plitvice",
+  "explore_do_label": "Activities",
+  "explore_beaches_label": "Seaside",
+  "explore_trips_label": "Day trips",
+  "explore_food_label": "Food & Drink"
 }

--- a/content/hr.json
+++ b/content/hr.json
@@ -63,5 +63,18 @@
   "highlights_h": "Istaknuto",
   "gallery_h": "Galerija",
   "avail_label": "Kalendar",
-  "availability_h": "Dostupnost"
+  "availability_h": "Dostupnost",
+
+  "amenities_label": "Sadržaji",
+  "weather_label": "Vremenska prognoza",
+  "discover_olive": "Otkrij Olive",
+  "discover_onyx": "Otkrij Onyx",
+  "stat_beach": "do plaže",
+  "stat_opatija": "do Opatije",
+  "stat_airport": "do aerodroma Pula",
+  "stat_plitvice": "do Plitvica",
+  "explore_do_label": "Aktivnosti",
+  "explore_beaches_label": "Plaže",
+  "explore_trips_label": "Izleti",
+  "explore_food_label": "Hrana i piće"
 }

--- a/content/hu.json
+++ b/content/hu.json
@@ -63,5 +63,18 @@
   "highlights_h": "Kiemelések",
   "gallery_h": "Galéria",
   "avail_label": "Naptár",
-  "availability_h": "Elérhetőség"
+  "availability_h": "Elérhetőség",
+
+  "amenities_label": "Felszereltség",
+  "weather_label": "Időjárás",
+  "discover_olive": "Olive felfedezése",
+  "discover_onyx": "Onyx felfedezése",
+  "stat_beach": "a strandig",
+  "stat_opatija": "Opatijáig",
+  "stat_airport": "Pula repülőtérig",
+  "stat_plitvice": "Plitvicéig",
+  "explore_do_label": "Programok",
+  "explore_beaches_label": "Strandok",
+  "explore_trips_label": "Kirándulások",
+  "explore_food_label": "Gasztronómia"
 }

--- a/content/it.json
+++ b/content/it.json
@@ -63,5 +63,18 @@
   "highlights_h": "Highlights",
   "gallery_h": "Galleria",
   "avail_label": "Calendario",
-  "availability_h": "Disponibilità"
+  "availability_h": "Disponibilità",
+
+  "amenities_label": "Servizi",
+  "weather_label": "Meteo",
+  "discover_olive": "Scopri Olive",
+  "discover_onyx": "Scopri Onyx",
+  "stat_beach": "alla spiaggia",
+  "stat_opatija": "a Opatija",
+  "stat_airport": "all'aeroporto di Pola",
+  "stat_plitvice": "ai Laghi di Plitvice",
+  "explore_do_label": "Attività",
+  "explore_beaches_label": "Mare",
+  "explore_trips_label": "Gite",
+  "explore_food_label": "Gastronomia"
 }

--- a/content/sk.json
+++ b/content/sk.json
@@ -63,5 +63,18 @@
   "highlights_h": "Highlights",
   "gallery_h": "Galéria",
   "avail_label": "Kalendár",
-  "availability_h": "Dostupnosť"
+  "availability_h": "Dostupnosť",
+
+  "amenities_label": "Vybavenie",
+  "weather_label": "Počasie",
+  "discover_olive": "Objaviť Olive",
+  "discover_onyx": "Objaviť Onyx",
+  "stat_beach": "na pláž",
+  "stat_opatija": "do Opatije",
+  "stat_airport": "na letisko Pula",
+  "stat_plitvice": "k Plitvickým jazerám",
+  "explore_do_label": "Aktivity",
+  "explore_beaches_label": "Pláže",
+  "explore_trips_label": "Výlety",
+  "explore_food_label": "Jedlo a nápoje"
 }

--- a/content/sl.json
+++ b/content/sl.json
@@ -63,5 +63,18 @@
   "highlights_h": "Poudarki",
   "gallery_h": "Galerija",
   "avail_label": "Koledar",
-  "availability_h": "Razpoložljivost"
+  "availability_h": "Razpoložljivost",
+
+  "amenities_label": "Ugodnosti",
+  "weather_label": "Vreme",
+  "discover_olive": "Odkrijte Olive",
+  "discover_onyx": "Odkrijte Onyx",
+  "stat_beach": "do plaže",
+  "stat_opatija": "do Opatije",
+  "stat_airport": "do letališča Pula",
+  "stat_plitvice": "do Plitvičkih jezer",
+  "explore_do_label": "Aktivnosti",
+  "explore_beaches_label": "Plaže",
+  "explore_trips_label": "Izleti",
+  "explore_food_label": "Hrana in pijača"
 }

--- a/content/uk.json
+++ b/content/uk.json
@@ -63,5 +63,18 @@
   "highlights_h": "Особливості",
   "gallery_h": "Галерея",
   "avail_label": "Календар",
-  "availability_h": "Наявність"
+  "availability_h": "Наявність",
+
+  "amenities_label": "Зручності",
+  "weather_label": "Погода",
+  "discover_olive": "Переглянути Olive",
+  "discover_onyx": "Переглянути Onyx",
+  "stat_beach": "до пляжу",
+  "stat_opatija": "до Опатії",
+  "stat_airport": "до аеропорту Пула",
+  "stat_plitvice": "до Плітвицьких озер",
+  "explore_do_label": "Активності",
+  "explore_beaches_label": "Пляжі",
+  "explore_trips_label": "Екскурсії",
+  "explore_food_label": "Їжа та напої"
 }


### PR DESCRIPTION
Found additional data-i18n keys used in HTML but missing from JSON: amenities_label, weather_label, discover_olive, discover_onyx, stat_beach, stat_opatija, stat_airport, stat_plitvice (index.html) and explore_do_label, explore_beaches_label, explore_trips_label, explore_food_label (explore.html). These caused the page to appear completely untranslated even after switching language, because most visible text elements had no matching translation key.