### PR TITLE
Fix contact form: remove duplicate id from section wrapper

### DIFF
--- a/apartments/olive.html
+++ b/apartments/olive.html
@@ -172,7 +172,7 @@
   </section>
 
   <!-- CONTACT FORM -->
-  <section class="section alt" id="contact-form">
+  <section class="section alt" id="apt-contact">
     <div class="container fade-up">
       <div class="section-label" data-i18n="contact_label">Contact</div>
       <h2 data-i18n="contact_h">Get in touch</h2>

--- a/apartments/onyx.html
+++ b/apartments/onyx.html
@@ -172,7 +172,7 @@
   </section>
 
   <!-- CONTACT FORM -->
-  <section class="section alt" id="contact-form">
+  <section class="section alt" id="apt-contact">
     <div class="container fade-up">
       <div class="section-label" data-i18n="contact_label">Contact</div>
       <h2 data-i18n="contact_h">Get in touch</h2>


### PR DESCRIPTION
Both <section> and <form> had id="contact-form". getElementById returned the section (first DOM match), so the submit listener never fired. Renamed section id to apt-contact; form keeps id="contact-form".