### PR TITLE
Fix: skip STATUS:CANCELLED events in iCal parser

### DIFF
--- a/content/guest/cs.json
+++ b/content/guest/cs.json
@@ -59,7 +59,11 @@
         "Ružmarin, Opatija — [Mapa](https://maps.app.goo.gl/cPMscVMU4gnontM97)",
         "Johnson Restaurant, Mošćenička Draga — [Mapa](https://maps.app.goo.gl/aobtvfK67GLamKRC8)",
         "Bistro Fortica, Kastav — [Mapa](https://maps.app.goo.gl/1gJWz9zBvvuKYdju5)",
-        "Istranka, Opatija — [Mapa](https://maps.app.goo.gl/vA9B6eCD3rv4LkJ78)"
+        "Istranka, Opatija — [Mapa](https://maps.app.goo.gl/vA9B6eCD3rv4LkJ78)",
+        "Lovranska Vrata, Lovran — [Mapa](https://www.google.com/maps/search/Lovranska+Vrata+Lovran)",
+        "Konoba Kali, Medveja — [Mapa](https://www.google.com/maps/search/Konoba+Kali+Medveja)",
+        "Bevanda, Opatija — [Mapa](https://www.google.com/maps/search/Bevanda+restaurant+Opatija)",
+        "Trattoria Mandrać, Volosko — [Mapa](https://www.google.com/maps/search/Trattoria+Mandrac+Volosko)"
       ]
     },
     {

--- a/content/guest/de.json
+++ b/content/guest/de.json
@@ -59,7 +59,11 @@
         "Ružmarin, Opatija — [Karte](https://maps.app.goo.gl/cPMscVMU4gnontM97)",
         "Johnson, Mošćenička Draga — [Karte](https://maps.app.goo.gl/aobtvfK67GLamKRC8)",
         "Bistro Fortica, Kastav — [Karte](https://maps.app.goo.gl/1gJWz9zBvvuKYdju5)",
-        "Istranka, Opatija — [Karte](https://maps.app.goo.gl/vA9B6eCD3rv4LkJ78)"
+        "Istranka, Opatija — [Karte](https://maps.app.goo.gl/vA9B6eCD3rv4LkJ78)",
+        "Lovranska Vrata, Lovran — [Karte](https://www.google.com/maps/search/Lovranska+Vrata+Lovran)",
+        "Konoba Kali, Medveja — [Karte](https://www.google.com/maps/search/Konoba+Kali+Medveja)",
+        "Bevanda, Opatija — [Karte](https://www.google.com/maps/search/Bevanda+restaurant+Opatija)",
+        "Trattoria Mandrać, Volosko — [Karte](https://www.google.com/maps/search/Trattoria+Mandrac+Volosko)"
       ]
     },
     {

--- a/content/guest/en.json
+++ b/content/guest/en.json
@@ -59,7 +59,11 @@
         "Ružmarin, Opatija — [Map](https://maps.app.goo.gl/cPMscVMU4gnontM97)",
         "Johnson Restaurant, Mošćenička Draga — [Map](https://maps.app.goo.gl/aobtvfK67GLamKRC8)",
         "Bistro Fortica, Kastav — [Map](https://maps.app.goo.gl/1gJWz9zBvvuKYdju5)",
-        "Istranka, Opatija — [Map](https://maps.app.goo.gl/vA9B6eCD3rv4LkJ78)"
+        "Istranka, Opatija — [Map](https://maps.app.goo.gl/vA9B6eCD3rv4LkJ78)",
+        "Lovranska Vrata, Lovran — [Map](https://www.google.com/maps/search/Lovranska+Vrata+Lovran)",
+        "Konoba Kali, Medveja — [Map](https://www.google.com/maps/search/Konoba+Kali+Medveja)",
+        "Bevanda, Opatija — [Map](https://www.google.com/maps/search/Bevanda+restaurant+Opatija)",
+        "Trattoria Mandrać, Volosko — [Map](https://www.google.com/maps/search/Trattoria+Mandrac+Volosko)"
       ]
     },
     {

--- a/content/guest/hr.json
+++ b/content/guest/hr.json
@@ -59,7 +59,11 @@
         "Ružmarin, Opatija — [Karta](https://maps.app.goo.gl/cPMscVMU4gnontM97)",
         "Johnson, Mošćenička Draga — [Karta](https://maps.app.goo.gl/aobtvfK67GLamKRC8)",
         "Bistro Fortica, Kastav — [Karta](https://maps.app.goo.gl/1gJWz9zBvvuKYdju5)",
-        "Istranka, Opatija — [Karta](https://maps.app.goo.gl/vA9B6eCD3rv4LkJ78)"
+        "Istranka, Opatija — [Karta](https://maps.app.goo.gl/vA9B6eCD3rv4LkJ78)",
+        "Lovranska Vrata, Lovran — [Karta](https://www.google.com/maps/search/Lovranska+Vrata+Lovran)",
+        "Konoba Kali, Medveja — [Karta](https://www.google.com/maps/search/Konoba+Kali+Medveja)",
+        "Bevanda, Opatija — [Karta](https://www.google.com/maps/search/Bevanda+restaurant+Opatija)",
+        "Trattoria Mandrać, Volosko — [Karta](https://www.google.com/maps/search/Trattoria+Mandrac+Volosko)"
       ]
     },
     {

--- a/content/guest/hu.json
+++ b/content/guest/hu.json
@@ -59,7 +59,11 @@
         "Ružmarin, Opatija — [Térkép](https://maps.app.goo.gl/cPMscVMU4gnontM97)",
         "Johnson Restaurant, Mošćenička Draga — [Térkép](https://maps.app.goo.gl/aobtvfK67GLamKRC8)",
         "Bistro Fortica, Kastav — [Térkép](https://maps.app.goo.gl/1gJWz9zBvvuKYdju5)",
-        "Istranka, Opatija — [Térkép](https://maps.app.goo.gl/vA9B6eCD3rv4LkJ78)"
+        "Istranka, Opatija — [Térkép](https://maps.app.goo.gl/vA9B6eCD3rv4LkJ78)",
+        "Lovranska Vrata, Lovran — [Térkép](https://www.google.com/maps/search/Lovranska+Vrata+Lovran)",
+        "Konoba Kali, Medveja — [Térkép](https://www.google.com/maps/search/Konoba+Kali+Medveja)",
+        "Bevanda, Opatija — [Térkép](https://www.google.com/maps/search/Bevanda+restaurant+Opatija)",
+        "Trattoria Mandrać, Volosko — [Térkép](https://www.google.com/maps/search/Trattoria+Mandrac+Volosko)"
       ]
     },
     {

--- a/content/guest/it.json
+++ b/content/guest/it.json
@@ -59,7 +59,11 @@
         "Ružmarin, Opatija — [Mappa](https://maps.app.goo.gl/cPMscVMU4gnontM97)",
         "Johnson, Mošćenička Draga — [Mappa](https://maps.app.goo.gl/aobtvfK67GLamKRC8)",
         "Bistro Fortica, Kastav — [Mappa](https://maps.app.goo.gl/1gJWz9zBvvuKYdju5)",
-        "Istranka, Opatija — [Mappa](https://maps.app.goo.gl/vA9B6eCD3rv4LkJ78)"
+        "Istranka, Opatija — [Mappa](https://maps.app.goo.gl/vA9B6eCD3rv4LkJ78)",
+        "Lovranska Vrata, Lovran — [Mappa](https://www.google.com/maps/search/Lovranska+Vrata+Lovran)",
+        "Konoba Kali, Medveja — [Mappa](https://www.google.com/maps/search/Konoba+Kali+Medveja)",
+        "Bevanda, Opatija — [Mappa](https://www.google.com/maps/search/Bevanda+restaurant+Opatija)",
+        "Trattoria Mandrać, Volosko — [Mappa](https://www.google.com/maps/search/Trattoria+Mandrac+Volosko)"
       ]
     },
     {

--- a/content/guest/sk.json
+++ b/content/guest/sk.json
@@ -59,7 +59,11 @@
         "Ružmarin, Opatija — [Mapa](https://maps.app.goo.gl/cPMscVMU4gnontM97)",
         "Johnson Restaurant, Mošćenička Draga — [Mapa](https://maps.app.goo.gl/aobtvfK67GLamKRC8)",
         "Bistro Fortica, Kastav — [Mapa](https://maps.app.goo.gl/1gJWz9zBvvuKYdju5)",
-        "Istranka, Opatija — [Mapa](https://maps.app.goo.gl/vA9B6eCD3rv4LkJ78)"
+        "Istranka, Opatija — [Mapa](https://maps.app.goo.gl/vA9B6eCD3rv4LkJ78)",
+        "Lovranska Vrata, Lovran — [Mapa](https://www.google.com/maps/search/Lovranska+Vrata+Lovran)",
+        "Konoba Kali, Medveja — [Mapa](https://www.google.com/maps/search/Konoba+Kali+Medveja)",
+        "Bevanda, Opatija — [Mapa](https://www.google.com/maps/search/Bevanda+restaurant+Opatija)",
+        "Trattoria Mandrać, Volosko — [Mapa](https://www.google.com/maps/search/Trattoria+Mandrac+Volosko)"
       ]
     },
     {

--- a/content/guest/sl.json
+++ b/content/guest/sl.json
@@ -59,7 +59,11 @@
         "Ružmarin, Opatija — [Zemljevid](https://maps.app.goo.gl/cPMscVMU4gnontM97)",
         "Johnson, Mošćenička Draga — [Zemljevid](https://maps.app.goo.gl/aobtvfK67GLamKRC8)",
         "Bistro Fortica, Kastav — [Zemljevid](https://maps.app.goo.gl/1gJWz9zBvvuKYdju5)",
-        "Istranka, Opatija — [Zemljevid](https://maps.app.goo.gl/vA9B6eCD3rv4LkJ78)"
+        "Istranka, Opatija — [Zemljevid](https://maps.app.goo.gl/vA9B6eCD3rv4LkJ78)",
+        "Lovranska Vrata, Lovran — [Zemljevid](https://www.google.com/maps/search/Lovranska+Vrata+Lovran)",
+        "Konoba Kali, Medveja — [Zemljevid](https://www.google.com/maps/search/Konoba+Kali+Medveja)",
+        "Bevanda, Opatija — [Zemljevid](https://www.google.com/maps/search/Bevanda+restaurant+Opatija)",
+        "Trattoria Mandrać, Volosko — [Zemljevid](https://www.google.com/maps/search/Trattoria+Mandrac+Volosko)"
       ]
     },
     {

--- a/content/guest/uk.json
+++ b/content/guest/uk.json
@@ -59,7 +59,11 @@
         "Ružmarin, Opatija — [Карта](https://maps.app.goo.gl/cPMscVMU4gnontM97)",
         "Johnson Restaurant, Mošćenička Draga — [Карта](https://maps.app.goo.gl/aobtvfK67GLamKRC8)",
         "Bistro Fortica, Kastav — [Карта](https://maps.app.goo.gl/1gJWz9zBvvuKYdju5)",
-        "Istranka, Opatija — [Карта](https://maps.app.goo.gl/vA9B6eCD3rv4LkJ78)"
+        "Istranka, Opatija — [Карта](https://maps.app.goo.gl/vA9B6eCD3rv4LkJ78)",
+        "Lovranska Vrata, Lovran — [Карта](https://www.google.com/maps/search/Lovranska+Vrata+Lovran)",
+        "Konoba Kali, Medveja — [Карта](https://www.google.com/maps/search/Konoba+Kali+Medveja)",
+        "Bevanda, Opatija — [Карта](https://www.google.com/maps/search/Bevanda+restaurant+Opatija)",
+        "Trattoria Mandrać, Volosko — [Карта](https://www.google.com/maps/search/Trattoria+Mandrac+Volosko)"
       ]
     },
     {

--- a/functions/api/ical/[apt].ts
+++ b/functions/api/ical/[apt].ts
@@ -116,6 +116,7 @@ function parseICS(raw: string): { start: string; end: string }[] {
 
   for (const chunk of events) {
     if (!/BEGIN:VEVENT/.test(chunk)) continue;
+    if (/^STATUS:CANCELLED/im.test(chunk)) continue;
     const dtStart = matchProp(chunk, "DTSTART");
     const dtEnd   = matchProp(chunk, "DTEND");
     if (!dtStart) continue;

--- a/guest/index.html
+++ b/guest/index.html
@@ -6,6 +6,14 @@
   <title>Guest Information — Aura Adriatica</title>
   <meta name="robots" content="noindex,nofollow" />
   <meta name="description" content="Useful insider information for your stay at Aura Adriatica Apartments." />
+  <meta name="theme-color" content="#b8965a">
+
+  <!-- Favicons -->
+  <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/assets/favicons/favicon-16x16.png">
+  <link rel="manifest" href="/assets/favicons/site.webmanifest">
+  <link rel="shortcut icon" href="/assets/favicons/favicon.ico">
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -174,6 +182,9 @@
     }
   </style>
 
+  <!-- Hero image preload -->
+  <link rel="preload" as="image" fetchpriority="high" href="/assets/img/guest-hero.webp">
+
   <script src="/assets/js/i18n.js" defer></script>
   <script src="/assets/js/ui.js" defer></script>
   <script src="/assets/js/guest.js?v=20260304" defer></script>
@@ -195,6 +206,7 @@
       <a href="/apartments/onyx.html" data-i18n="onyx_h">Onyx</a>
       <a href="/explore.html" data-i18n="explore">Explore</a>
       <a href="/gallery.html" data-i18n="gallery">Gallery</a>
+      <a href="/contact.html" data-i18n="contact_nav">Contact</a>
     </nav>
     <button class="nav-toggle" id="nav-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" aria-controls="main-nav">
       <span></span><span></span><span></span>


### PR DESCRIPTION
Cancelled bookings were incorrectly shown as booked in the calendar.